### PR TITLE
Fix order validation

### DIFF
--- a/10-e-commerce-api/final/controllers/orderController.js
+++ b/10-e-commerce-api/final/controllers/orderController.js
@@ -16,11 +16,11 @@ const createOrder = async (req, res) => {
   if (!cartItems || cartItems.length < 1) {
     throw new CustomError.BadRequestError('No cart items provided');
   }
-  if (!tax || !shippingFee) {
-    throw new CustomError.BadRequestError(
-      'Please provide tax and shipping fee'
-    );
-  }
+  if (tax === undefined || shippingFee === undefined) {
+      throw new CustomError.BadRequestError(
+        'Please provide tax and shipping fee'
+      );
+    }
 
   let orderItems = [];
   let subtotal = 0;


### PR DESCRIPTION
## Summary
- handle 0 values for tax and shipping fee when creating orders

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_683f3c001628832ab0a6fbb48b07ef2a